### PR TITLE
Add Protocol model with DRF endpoints

### DIFF
--- a/bionexus-platform/backend/core/urls.py
+++ b/bionexus-platform/backend/core/urls.py
@@ -1,0 +1,11 @@
+from django.urls import include, path
+from rest_framework.routers import DefaultRouter
+
+from modules.protocols.views import ProtocolViewSet
+
+router = DefaultRouter()
+router.register(r"protocols", ProtocolViewSet, basename="protocol")
+
+urlpatterns = [
+    path("api/", include(router.urls)),
+]

--- a/bionexus-platform/backend/modules/protocols/models.py
+++ b/bionexus-platform/backend/modules/protocols/models.py
@@ -1,0 +1,15 @@
+from django.db import models
+
+
+class Protocol(models.Model):
+    """Represents a laboratory or analysis protocol."""
+
+    title = models.CharField(max_length=255)
+    description = models.TextField(blank=True)
+    steps = models.TextField(blank=True)
+
+    class Meta:
+        app_label = "protocols"
+
+    def __str__(self) -> str:
+        return self.title

--- a/bionexus-platform/backend/modules/protocols/views.py
+++ b/bionexus-platform/backend/modules/protocols/views.py
@@ -1,0 +1,18 @@
+from rest_framework import serializers, viewsets
+
+from .models import Protocol
+
+
+class ProtocolSerializer(serializers.ModelSerializer):
+    """Serializer for the Protocol model."""
+
+    class Meta:
+        model = Protocol
+        fields = ["id", "title", "description", "steps"]
+
+
+class ProtocolViewSet(viewsets.ModelViewSet):
+    """API endpoint for listing and managing protocols."""
+
+    queryset = Protocol.objects.all()
+    serializer_class = ProtocolSerializer


### PR DESCRIPTION
## Summary
- add Protocol model for storing protocol title, description, and steps
- implement DRF serializer and viewset for managing protocols
- expose protocol endpoints through project's URL router

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6894685e3cd083319da86301ad86e192