### PR TITLE
Add backend requirements for bionexus platform

### DIFF
--- a/bionexus-platform/backend/requirements.txt
+++ b/bionexus-platform/backend/requirements.txt
@@ -1,0 +1,3 @@
+django
+djangorestframework
+pytest


### PR DESCRIPTION
## Summary
- add Django, DRF, and pytest to bionexus backend requirements

## Testing
- `cd bionexus-platform && pip install -r backend/requirements.txt`


------
https://chatgpt.com/codex/tasks/task_e_6894685f0a20833189babcc87ee1ef23