### PR TITLE
Add React frontend scaffolding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,7 @@ __pycache__/
 # Fichiers sensibles
 .env
 
+# Node build artifacts
+node_modules/
+dist/
+

--- a/bionexus-platform/frontend/index.html
+++ b/bionexus-platform/frontend/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>BioNexus Frontend</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/bionexus-platform/frontend/package.json
+++ b/bionexus-platform/frontend/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "bionexus-frontend",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "start": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "test": "echo \"No tests specified\" && exit 0"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.22.3"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.2.0",
+    "vite": "^5.1.0"
+  }
+}

--- a/bionexus-platform/frontend/src/App.js
+++ b/bionexus-platform/frontend/src/App.js
@@ -1,0 +1,13 @@
+import React from 'react';
+import { BrowserRouter } from 'react-router-dom';
+import AppRoutes from './routes';
+
+function App() {
+  return (
+    <BrowserRouter>
+      <AppRoutes />
+    </BrowserRouter>
+  );
+}
+
+export default App;

--- a/bionexus-platform/frontend/src/main.jsx
+++ b/bionexus-platform/frontend/src/main.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/bionexus-platform/frontend/src/routes.js
+++ b/bionexus-platform/frontend/src/routes.js
@@ -1,0 +1,14 @@
+import React from 'react';
+import { Routes, Route } from 'react-router-dom';
+
+function Home() {
+  return <h1>BioNexus UI</h1>;
+}
+
+export default function AppRoutes() {
+  return (
+    <Routes>
+      <Route path="/" element={<Home />} />
+    </Routes>
+  );
+}


### PR DESCRIPTION
## Summary
- configure frontend package.json with React, React Router and Vite scripts
- implement App component with BrowserRouter and route definitions
- provide basic HTML entry point and React DOM bootstrap

## Testing
- `npm test`
- `npm start` *(fails: vite not found, dependencies could not be installed)*

------
https://chatgpt.com/codex/tasks/task_e_689468605f10833181ed37f019d4cf9f