### PR TITLE
Add Django management script

### DIFF
--- a/bionexus-platform/backend/manage.py
+++ b/bionexus-platform/backend/manage.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python
+"""Django's command-line utility for administrative tasks."""
+import os
+import sys
+
+
+def main() -> None:
+    """Run administrative tasks."""
+    os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'core.settings')
+    try:
+        from django.core.management import execute_from_command_line
+    except ImportError as exc:
+        raise ImportError(
+            "Couldn't import Django. Are you sure it's installed and "
+            "available on your PYTHONPATH environment variable? Did you "
+            "forget to activate a virtual environment?"
+        ) from exc
+    execute_from_command_line(sys.argv)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- Add standard Django manage.py referencing core.settings and make it executable

## Testing
- `python backend/manage.py check`


------
https://chatgpt.com/codex/tasks/task_e_6894685d995c8331a58cf15088d32e37