### PR TITLE
Add CRUD API tests for samples and protocols

### DIFF
--- a/backend/test_example.py
+++ b/backend/test_example.py
@@ -1,2 +1,0 @@
-def test_placeholder():
-    assert 1 == 1

--- a/bionexus-platform/backend/core/settings.py
+++ b/bionexus-platform/backend/core/settings.py
@@ -1,4 +1,20 @@
+SECRET_KEY = 'test-secret-key'
+
 INSTALLED_APPS = [
-    "rest_framework",
-    "modules.samples",
+    'django.contrib.auth',
+    'django.contrib.contenttypes',
+    'rest_framework',
+    'modules.samples',
+    'modules.protocols',
 ]
+
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.sqlite3',
+        'NAME': ':memory:',
+    }
+}
+
+ROOT_URLCONF = 'core.urls'
+
+MIDDLEWARE = []

--- a/bionexus-platform/backend/core/urls.py
+++ b/bionexus-platform/backend/core/urls.py
@@ -1,23 +1,13 @@
 from django.urls import include, path
 from rest_framework.routers import DefaultRouter
 
- codex/add-sample-model-and-crud-views
 from modules.samples.views import SampleViewSet
-
-
-router = DefaultRouter()
-router.register(r"samples", SampleViewSet)
-
-
-urlpatterns = [
-    path("", include(router.urls)),
-
 from modules.protocols.views import ProtocolViewSet
 
 router = DefaultRouter()
-router.register(r"protocols", ProtocolViewSet, basename="protocol")
+router.register(r'samples', SampleViewSet)
+router.register(r'protocols', ProtocolViewSet, basename='protocol')
 
 urlpatterns = [
-    path("api/", include(router.urls)),
- main
+    path('api/', include(router.urls)),
 ]

--- a/bionexus-platform/backend/modules/protocols/tests/test_protocols_api.py
+++ b/bionexus-platform/backend/modules/protocols/tests/test_protocols_api.py
@@ -1,0 +1,36 @@
+from django.test import TestCase
+from rest_framework.test import APIClient
+
+
+class ProtocolAPITest(TestCase):
+    """Integration tests for Protocol endpoints."""
+
+    def setUp(self):
+        self.client = APIClient()
+
+    def test_protocol_crud_operations(self):
+        payload = {
+            "title": "DNA Extraction",
+            "description": "Basic protocol",
+            "steps": "Step 1",
+        }
+
+        response = self.client.post("/api/protocols/", payload, format="json")
+        self.assertEqual(response.status_code, 201)
+        protocol_id = response.data["id"]
+
+        response = self.client.get(f"/api/protocols/{protocol_id}/")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data["title"], "DNA Extraction")
+
+        response = self.client.patch(
+            f"/api/protocols/{protocol_id}/", {"title": "Updated"}, format="json"
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data["title"], "Updated")
+
+        response = self.client.delete(f"/api/protocols/{protocol_id}/")
+        self.assertEqual(response.status_code, 204)
+        self.assertEqual(
+            self.client.get(f"/api/protocols/{protocol_id}/").status_code, 404
+        )

--- a/bionexus-platform/backend/modules/samples/tests/test_samples_api.py
+++ b/bionexus-platform/backend/modules/samples/tests/test_samples_api.py
@@ -1,0 +1,38 @@
+from django.test import TestCase
+from django.utils import timezone
+from rest_framework.test import APIClient
+
+
+class SampleAPITest(TestCase):
+    """Integration tests for Sample endpoints."""
+
+    def setUp(self):
+        self.client = APIClient()
+
+    def test_sample_crud_operations(self):
+        payload = {
+            "name": "Sample A",
+            "type": "blood",
+            "received_at": timezone.now().isoformat(),
+            "location": "Freezer 1",
+        }
+
+        response = self.client.post("/api/samples/", payload, format="json")
+        self.assertEqual(response.status_code, 201)
+        sample_id = response.data["id"]
+
+        response = self.client.get(f"/api/samples/{sample_id}/")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data["name"], "Sample A")
+
+        response = self.client.patch(
+            f"/api/samples/{sample_id}/", {"name": "Updated"}, format="json"
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data["name"], "Updated")
+
+        response = self.client.delete(f"/api/samples/{sample_id}/")
+        self.assertEqual(response.status_code, 204)
+        self.assertEqual(
+            self.client.get(f"/api/samples/{sample_id}/").status_code, 404
+        )

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,14 @@
+import os
+import sys
+import django
+from django.core.management import call_command
+
+BASE_DIR = os.path.dirname(__file__)
+BACKEND_DIR = os.path.join(BASE_DIR, 'bionexus-platform', 'backend')
+if BACKEND_DIR not in sys.path:
+    sys.path.insert(0, BACKEND_DIR)
+
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'core.settings')
+
+django.setup()
+call_command('migrate', run_syncdb=True, verbosity=0)


### PR DESCRIPTION
## Summary
- remove old example test
- add DRF CRUD tests for samples and protocols
- configure minimal Django settings and URLs for API tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68946b0b0f2c8331a880c519cb812292