### PR TITLE
feat(frontend): add vite config and basic tests

### DIFF
--- a/bionexus-platform/frontend/package.json
+++ b/bionexus-platform/frontend/package.json
@@ -6,7 +6,7 @@
     "start": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "test": "echo \"No tests specified\" && exit 0"
+    "test": "vitest"
   },
   "dependencies": {
     "react": "^18.2.0",
@@ -15,6 +15,10 @@
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^4.2.0",
-    "vite": "^5.1.0"
+    "vite": "^5.1.0",
+    "@testing-library/jest-dom": "^6.1.5",
+    "@testing-library/react": "^14.2.1",
+    "jsdom": "^24.0.0",
+    "vitest": "^1.5.0"
   }
 }

--- a/bionexus-platform/frontend/src/__tests__/App.test.jsx
+++ b/bionexus-platform/frontend/src/__tests__/App.test.jsx
@@ -1,0 +1,8 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import App from '../App';
+
+test('renders BioNexus UI heading', () => {
+  render(<App />);
+  expect(screen.getByRole('heading', { name: /bionexus ui/i })).toBeInTheDocument();
+});

--- a/bionexus-platform/frontend/vite.config.js
+++ b/bionexus-platform/frontend/vite.config.js
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  root: './',
+  test: {
+    environment: 'jsdom',
+    globals: true,
+  },
+});


### PR DESCRIPTION
## Summary
- configure vite with React plugin and jsdom test env
- add a basic React Testing Library test for App component
- update test script and dev dependencies

## Testing
- `npm test` *(fails: vitest not found; npm install blocked)*


------
https://chatgpt.com/codex/tasks/task_e_68946b0cabc883318f8e57e07f4d181b