### PR TITLE
Add protocols module to Django settings

### DIFF
--- a/bionexus-platform/backend/core/settings.py
+++ b/bionexus-platform/backend/core/settings.py
@@ -1,4 +1,5 @@
 INSTALLED_APPS = [
     "rest_framework",
     "modules.samples",
+    "modules.protocols",
 ]


### PR DESCRIPTION
## Summary
- include `modules.protocols` in Django `INSTALLED_APPS`

## Testing
- `python manage.py migrate` *(fails: settings.DATABASES is improperly configured)*
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68946b0b8998833185ccd80242a7dda8