### PR TITLE
refactor: move protocol serializer to dedicated module

### DIFF
--- a/bionexus-platform/backend/modules/protocols/serializers.py
+++ b/bionexus-platform/backend/modules/protocols/serializers.py
@@ -1,0 +1,11 @@
+from rest_framework import serializers
+
+from .models import Protocol
+
+
+class ProtocolSerializer(serializers.ModelSerializer):
+    """Serializer for the Protocol model."""
+
+    class Meta:
+        model = Protocol
+        fields = ["id", "title", "description", "steps"]

--- a/bionexus-platform/backend/modules/protocols/views.py
+++ b/bionexus-platform/backend/modules/protocols/views.py
@@ -1,14 +1,7 @@
-from rest_framework import serializers, viewsets
+from rest_framework import viewsets
 
 from .models import Protocol
-
-
-class ProtocolSerializer(serializers.ModelSerializer):
-    """Serializer for the Protocol model."""
-
-    class Meta:
-        model = Protocol
-        fields = ["id", "title", "description", "steps"]
+from .serializers import ProtocolSerializer
 
 
 class ProtocolViewSet(viewsets.ModelViewSet):


### PR DESCRIPTION
## Summary
- move `ProtocolSerializer` into a new `serializers.py`
- update `ProtocolViewSet` to use the new serializer module

## Testing
- `cd bionexus-platform/backend && python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68946b0a529083319824cffc2beea2db