### PR TITLE
Add docker compose services and docs

### DIFF
--- a/bionexus-platform/README.md
+++ b/bionexus-platform/README.md
@@ -1,0 +1,38 @@
+# Bionexus Platform
+
+This directory contains a minimal development environment for the
+BioNexus MVP platform.  The stack is composed of a Django backend,
+PostgreSQL database, and a React frontend orchestrated through
+Docker Compose.
+
+## Environment Variables
+
+The following variables can be customised in a `.env` file or by
+overriding them when running `docker compose`.
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `POSTGRES_USER` | database user | `bionexus` |
+| `POSTGRES_PASSWORD` | database password | `bionexus` |
+| `POSTGRES_DB` | database name | `bionexus` |
+| `DATABASE_URL` | connection string used by Django | `postgres://bionexus:bionexus@db:5432/bionexus` |
+| `CHOKIDAR_USEPOLLING` | enables reliable hot reloading for the frontend inside Docker | `true` |
+
+## Usage
+
+From this directory run:
+
+```bash
+docker compose up --build
+```
+
+Services will be available at:
+
+- Backend: <http://localhost:8000>
+- Frontend: <http://localhost:3000>
+- PostgreSQL: `localhost:5432`
+
+Source code for the backend and frontend is mounted into the containers
+so that changes on the host trigger automatic reloads.  PostgreSQL data
+is stored in a named volume `postgres_data` to persist across runs.
+

--- a/bionexus-platform/docker-compose.yml
+++ b/bionexus-platform/docker-compose.yml
@@ -1,0 +1,46 @@
+version: "3.9"
+
+services:
+  db:
+    image: postgres:15
+    restart: always
+    environment:
+      POSTGRES_DB: ${POSTGRES_DB:-bionexus}
+      POSTGRES_USER: ${POSTGRES_USER:-bionexus}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-bionexus}
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+
+  backend:
+    image: python:3.11
+    working_dir: /app
+    volumes:
+      - ./backend:/app
+    command: >-
+      sh -c "pip install -r requirements.txt && python manage.py migrate && python manage.py runserver 0.0.0.0:8000"
+    environment:
+      DATABASE_URL: "${DATABASE_URL:-postgres://bionexus:bionexus@db:5432/bionexus}"
+    ports:
+      - "8000:8000"
+    depends_on:
+      - db
+
+  frontend:
+    image: node:18
+    working_dir: /app
+    volumes:
+      - ./frontend:/app
+      - /app/node_modules
+    command: npm start
+    environment:
+      CHOKIDAR_USEPOLLING: "true"
+    ports:
+      - "3000:3000"
+    depends_on:
+      - backend
+
+volumes:
+  postgres_data:
+


### PR DESCRIPTION
## Summary
- add docker-compose.yml configuring backend, frontend and PostgreSQL services with mapped ports and volumes
- document environment variables and usage in platform README

## Testing
- `docker compose config` *(fails: command not found)*
- `python -m py_compile backend/manage.py`
- `npm test --prefix frontend`

------
https://chatgpt.com/codex/tasks/task_e_68946b08914c8331a463dcd32208c4ab