### PR TITLE
Add API CRUD tests and run pytest in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,5 +23,6 @@ jobs:
           pip install -r bionexus-platform/backend/requirements.txt
 
       - name: Run tests
+        working-directory: bionexus-platform/backend
         run: |
-          pytest bionexus-platform/backend/
+          pytest -q

--- a/bionexus-platform/backend/core/settings.py
+++ b/bionexus-platform/backend/core/settings.py
@@ -1,31 +1,12 @@
- codex/update-django-settings-for-development
-
- codex/update-django-settings-for-development
- main
-"""Django settings for the BioNexus project."""
-
-from __future__ import annotations
-
 from pathlib import Path
 import os
 
-
-# Base directory of the project
 BASE_DIR = Path(__file__).resolve().parent.parent
 
-
-# --- Core Django settings -------------------------------------------------
-
-# SECURITY WARNING: keep the secret key used in production secret!
 SECRET_KEY = os.environ.get("DJANGO_SECRET_KEY", "dev-secret-key")
-
-# SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
+ALLOWED_HOSTS: list[str] = ["testserver", "localhost"]
 
-ALLOWED_HOSTS: list[str] = []
-
-
-# Application definition
 INSTALLED_APPS = [
     "django.contrib.admin",
     "django.contrib.auth",
@@ -33,7 +14,6 @@ INSTALLED_APPS = [
     "django.contrib.sessions",
     "django.contrib.messages",
     "django.contrib.staticfiles",
- codex/update-django-settings-for-development
     "rest_framework",
     "modules.samples",
     "modules.protocols",
@@ -69,8 +49,6 @@ TEMPLATES = [
 
 WSGI_APPLICATION = "core.wsgi.application"
 
-
-# Database configuration
 DATABASES = {
     "default": {
         "ENGINE": "django.db.backends.sqlite3",
@@ -78,8 +56,6 @@ DATABASES = {
     }
 }
 
-
-# Django REST Framework configuration
 REST_FRAMEWORK = {
     "DEFAULT_AUTHENTICATION_CLASSES": [
         "rest_framework.authentication.SessionAuthentication",
@@ -90,136 +66,10 @@ REST_FRAMEWORK = {
     ],
 }
 
-
-# Internationalization
 LANGUAGE_CODE = "en-us"
-
 TIME_ZONE = "UTC"
-
 USE_I18N = True
-
 USE_TZ = True
 
-
-# Static files
 STATIC_URL = "static/"
-
-
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
-
-
-
- codex/run-migrations-and-update-documentation
-from pathlib import Path
-
-BASE_DIR = Path(__file__).resolve().parent.parent
-
-SECRET_KEY = "dummy-secret-key"
-
-INSTALLED_APPS = [
-    "django.contrib.auth",
-    "django.contrib.contenttypes",
- main
-    "rest_framework",
-    "modules.samples",
-    "modules.protocols",
-]
-
- codex/update-django-settings-for-development
-MIDDLEWARE = [
-    "django.middleware.security.SecurityMiddleware",
-    "django.contrib.sessions.middleware.SessionMiddleware",
-    "django.middleware.common.CommonMiddleware",
-    "django.middleware.csrf.CsrfViewMiddleware",
-    "django.contrib.auth.middleware.AuthenticationMiddleware",
-    "django.contrib.messages.middleware.MessageMiddleware",
-    "django.middleware.clickjacking.XFrameOptionsMiddleware",
-]
-
-ROOT_URLCONF = "core.urls"
-
-TEMPLATES = [
-    {
-        "BACKEND": "django.template.backends.django.DjangoTemplates",
-        "DIRS": [],
-        "APP_DIRS": True,
-        "OPTIONS": {
-            "context_processors": [
-                "django.template.context_processors.debug",
-                "django.template.context_processors.request",
-                "django.contrib.auth.context_processors.auth",
-                "django.contrib.messages.context_processors.messages",
-            ],
-        },
-    }
-]
-
-WSGI_APPLICATION = "core.wsgi.application"
-
-
-# Database configuration
-
- main
-DATABASES = {
-    "default": {
-        "ENGINE": "django.db.backends.sqlite3",
-        "NAME": BASE_DIR / "db.sqlite3",
-    }
-}
-
- codex/update-django-settings-for-development
-
-# Django REST Framework configuration
-REST_FRAMEWORK = {
-    "DEFAULT_AUTHENTICATION_CLASSES": [
-        "rest_framework.authentication.SessionAuthentication",
-        "rest_framework.authentication.BasicAuthentication",
-    ],
-    "DEFAULT_PERMISSION_CLASSES": [
-        "rest_framework.permissions.AllowAny",
-    ],
-}
-
-
-# Internationalization
-LANGUAGE_CODE = "en-us"
-
-TIME_ZONE = "UTC"
-
-USE_I18N = True
-
-USE_TZ = True
-
-
-# Static files
-STATIC_URL = "static/"
-
-
-DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
-
-
-DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
-
-SECRET_KEY = 'test-secret-key'
-
-INSTALLED_APPS = [
-    'django.contrib.auth',
-    'django.contrib.contenttypes',
-    'rest_framework',
-    'modules.samples',
-    'modules.protocols',
-]
-
-DATABASES = {
-    'default': {
-        'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': ':memory:',
-    }
-}
-
-ROOT_URLCONF = 'core.urls'
-
-MIDDLEWARE = []
- main
- main
- main

--- a/bionexus-platform/backend/core/urls.py
+++ b/bionexus-platform/backend/core/urls.py
@@ -4,23 +4,10 @@ from rest_framework.routers import DefaultRouter
 from modules.samples.views import SampleViewSet
 from modules.protocols.views import ProtocolViewSet
 
- codex/refactor-urls-in-backend-core
-
 router = DefaultRouter()
 router.register(r"samples", SampleViewSet)
 router.register(r"protocols", ProtocolViewSet, basename="protocol")
 
-router = DefaultRouter()
-router.register(r'samples', SampleViewSet)
-router.register(r'protocols', ProtocolViewSet, basename='protocol')
- main
-
-
 urlpatterns = [
- codex/refactor-urls-in-backend-core
     path("api/", include(router.urls)),
-
-    path('api/', include(router.urls)),
- main
 ]
-

--- a/bionexus-platform/backend/modules/protocols/tests/test_protocols_api.py
+++ b/bionexus-platform/backend/modules/protocols/tests/test_protocols_api.py
@@ -19,6 +19,10 @@ class ProtocolAPITest(TestCase):
         self.assertEqual(response.status_code, 201)
         protocol_id = response.data["id"]
 
+        list_resp = self.client.get("/api/protocols/")
+        self.assertEqual(list_resp.status_code, 200)
+        self.assertTrue(any(p["id"] == protocol_id for p in list_resp.data))
+
         response = self.client.get(f"/api/protocols/{protocol_id}/")
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.data["title"], "DNA Extraction")
@@ -34,3 +38,6 @@ class ProtocolAPITest(TestCase):
         self.assertEqual(
             self.client.get(f"/api/protocols/{protocol_id}/").status_code, 404
         )
+
+        list_resp = self.client.get("/api/protocols/")
+        self.assertFalse(any(p["id"] == protocol_id for p in list_resp.data))

--- a/bionexus-platform/backend/modules/samples/tests/test_samples_api.py
+++ b/bionexus-platform/backend/modules/samples/tests/test_samples_api.py
@@ -21,6 +21,10 @@ class SampleAPITest(TestCase):
         self.assertEqual(response.status_code, 201)
         sample_id = response.data["id"]
 
+        list_resp = self.client.get("/api/samples/")
+        self.assertEqual(list_resp.status_code, 200)
+        self.assertTrue(any(s["id"] == sample_id for s in list_resp.data))
+
         response = self.client.get(f"/api/samples/{sample_id}/")
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.data["name"], "Sample A")
@@ -36,3 +40,6 @@ class SampleAPITest(TestCase):
         self.assertEqual(
             self.client.get(f"/api/samples/{sample_id}/").status_code, 404
         )
+
+        list_resp = self.client.get("/api/samples/")
+        self.assertFalse(any(s["id"] == sample_id for s in list_resp.data))

--- a/bionexus-platform/backend/test_example.py
+++ b/bionexus-platform/backend/test_example.py
@@ -1,2 +1,0 @@
-def test_placeholder():
-    assert 1 == 1


### PR DESCRIPTION
## Summary
- remove placeholder backend test and clean Django config
- add CRUD integration tests for Samples and Protocols using APIClient
- run pytest in CI workflow

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6894df8982a88331bf4396f805253534