### PR TITLE
Configure docker-compose services with environment variables

### DIFF
--- a/bionexus-platform/docker-compose.yml
+++ b/bionexus-platform/docker-compose.yml
@@ -21,7 +21,13 @@ services:
     command: >-
       sh -c "pip install -r requirements.txt && python manage.py migrate && python manage.py runserver 0.0.0.0:8000"
     environment:
+      DJANGO_SETTINGS_MODULE: core.settings
       DATABASE_URL: "${DATABASE_URL:-postgres://bionexus:bionexus@db:5432/bionexus}"
+      POSTGRES_DB: ${POSTGRES_DB:-bionexus}
+      POSTGRES_USER: ${POSTGRES_USER:-bionexus}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-bionexus}
+      DB_HOST: db
+      DB_PORT: 5432
     ports:
       - "8000:8000"
     depends_on:


### PR DESCRIPTION
## Summary
- add DJANGO_SETTINGS_MODULE and database credentials to backend service
- ensure docker-compose services for backend, database, and frontend expose ports and volumes

## Testing
- `PYTHONPATH=. DJANGO_SETTINGS_MODULE=core.settings pytest` *(fails: IndentationError in `core/settings.py`)*

------
https://chatgpt.com/codex/tasks/task_e_6894df814e188331aca88aab7944897d