### PR TITLE
Configure Django settings with env overrides

### DIFF
--- a/bionexus-platform/README.md
+++ b/bionexus-platform/README.md
@@ -16,7 +16,14 @@ overriding them when running `docker compose`.
 | `POSTGRES_PASSWORD` | database password | `bionexus` |
 | `POSTGRES_DB` | database name | `bionexus` |
 | `DATABASE_URL` | connection string used by Django | `postgres://bionexus:bionexus@db:5432/bionexus` |
+| `DJANGO_SECRET_KEY` | secret key used by Django | `dev-secret-key` |
+| `DJANGO_DEBUG` | enable debug mode (`true`/`false`) | `true` |
+| `DJANGO_ALLOWED_HOSTS` | comma separated hostnames Django can serve | `localhost,127.0.0.1,testserver` |
 | `CHOKIDAR_USEPOLLING` | enables reliable hot reloading for the frontend inside Docker | `true` |
+
+These variables override the defaults defined in `core/settings.py` and
+can be placed in a `.env` file or exported in your shell before
+starting the services.
 
 ## Usage
 

--- a/bionexus-platform/backend/core/settings.py
+++ b/bionexus-platform/backend/core/settings.py
@@ -1,18 +1,8 @@
- codex/update-django-settings-for-development
-
- codex/update-django-settings-for-development
- main
-"""Django settings for the BioNexus project."""
-
-from __future__ import annotations
-
-from pathlib import Path
 import os
-
+from pathlib import Path
 
 # Base directory of the project
 BASE_DIR = Path(__file__).resolve().parent.parent
-
 
 # --- Core Django settings -------------------------------------------------
 
@@ -20,10 +10,11 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 SECRET_KEY = os.environ.get("DJANGO_SECRET_KEY", "dev-secret-key")
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True
+DEBUG = os.environ.get("DJANGO_DEBUG", "true").lower() == "true"
 
-ALLOWED_HOSTS: list[str] = []
-
+ALLOWED_HOSTS = os.environ.get(
+    "DJANGO_ALLOWED_HOSTS", "localhost,127.0.0.1,testserver"
+).split(",")
 
 # Application definition
 INSTALLED_APPS = [
@@ -33,7 +24,6 @@ INSTALLED_APPS = [
     "django.contrib.sessions",
     "django.contrib.messages",
     "django.contrib.staticfiles",
- codex/update-django-settings-for-development
     "rest_framework",
     "modules.samples",
     "modules.protocols",
@@ -69,7 +59,6 @@ TEMPLATES = [
 
 WSGI_APPLICATION = "core.wsgi.application"
 
-
 # Database configuration
 DATABASES = {
     "default": {
@@ -78,6 +67,14 @@ DATABASES = {
     }
 }
 
+DATABASE_URL = os.environ.get("DATABASE_URL")
+if DATABASE_URL:
+    try:
+        import dj_database_url  # type: ignore
+    except Exception:  # pragma: no cover - dependency optional
+        pass
+    else:
+        DATABASES["default"] = dj_database_url.parse(DATABASE_URL)
 
 # Django REST Framework configuration
 REST_FRAMEWORK = {
@@ -90,7 +87,6 @@ REST_FRAMEWORK = {
     ],
 }
 
-
 # Internationalization
 LANGUAGE_CODE = "en-us"
 
@@ -100,126 +96,8 @@ USE_I18N = True
 
 USE_TZ = True
 
-
 # Static files
 STATIC_URL = "static/"
 
-
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 
-
-
- codex/run-migrations-and-update-documentation
-from pathlib import Path
-
-BASE_DIR = Path(__file__).resolve().parent.parent
-
-SECRET_KEY = "dummy-secret-key"
-
-INSTALLED_APPS = [
-    "django.contrib.auth",
-    "django.contrib.contenttypes",
- main
-    "rest_framework",
-    "modules.samples",
-    "modules.protocols",
-]
-
- codex/update-django-settings-for-development
-MIDDLEWARE = [
-    "django.middleware.security.SecurityMiddleware",
-    "django.contrib.sessions.middleware.SessionMiddleware",
-    "django.middleware.common.CommonMiddleware",
-    "django.middleware.csrf.CsrfViewMiddleware",
-    "django.contrib.auth.middleware.AuthenticationMiddleware",
-    "django.contrib.messages.middleware.MessageMiddleware",
-    "django.middleware.clickjacking.XFrameOptionsMiddleware",
-]
-
-ROOT_URLCONF = "core.urls"
-
-TEMPLATES = [
-    {
-        "BACKEND": "django.template.backends.django.DjangoTemplates",
-        "DIRS": [],
-        "APP_DIRS": True,
-        "OPTIONS": {
-            "context_processors": [
-                "django.template.context_processors.debug",
-                "django.template.context_processors.request",
-                "django.contrib.auth.context_processors.auth",
-                "django.contrib.messages.context_processors.messages",
-            ],
-        },
-    }
-]
-
-WSGI_APPLICATION = "core.wsgi.application"
-
-
-# Database configuration
-
- main
-DATABASES = {
-    "default": {
-        "ENGINE": "django.db.backends.sqlite3",
-        "NAME": BASE_DIR / "db.sqlite3",
-    }
-}
-
- codex/update-django-settings-for-development
-
-# Django REST Framework configuration
-REST_FRAMEWORK = {
-    "DEFAULT_AUTHENTICATION_CLASSES": [
-        "rest_framework.authentication.SessionAuthentication",
-        "rest_framework.authentication.BasicAuthentication",
-    ],
-    "DEFAULT_PERMISSION_CLASSES": [
-        "rest_framework.permissions.AllowAny",
-    ],
-}
-
-
-# Internationalization
-LANGUAGE_CODE = "en-us"
-
-TIME_ZONE = "UTC"
-
-USE_I18N = True
-
-USE_TZ = True
-
-
-# Static files
-STATIC_URL = "static/"
-
-
-DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
-
-
-DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
-
-SECRET_KEY = 'test-secret-key'
-
-INSTALLED_APPS = [
-    'django.contrib.auth',
-    'django.contrib.contenttypes',
-    'rest_framework',
-    'modules.samples',
-    'modules.protocols',
-]
-
-DATABASES = {
-    'default': {
-        'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': ':memory:',
-    }
-}
-
-ROOT_URLCONF = 'core.urls'
-
-MIDDLEWARE = []
- main
- main
- main

--- a/bionexus-platform/backend/core/urls.py
+++ b/bionexus-platform/backend/core/urls.py
@@ -4,23 +4,10 @@ from rest_framework.routers import DefaultRouter
 from modules.samples.views import SampleViewSet
 from modules.protocols.views import ProtocolViewSet
 
- codex/refactor-urls-in-backend-core
-
 router = DefaultRouter()
 router.register(r"samples", SampleViewSet)
 router.register(r"protocols", ProtocolViewSet, basename="protocol")
 
-router = DefaultRouter()
-router.register(r'samples', SampleViewSet)
-router.register(r'protocols', ProtocolViewSet, basename='protocol')
- main
-
-
 urlpatterns = [
- codex/refactor-urls-in-backend-core
     path("api/", include(router.urls)),
-
-    path('api/', include(router.urls)),
- main
 ]
-


### PR DESCRIPTION
## Summary
- add standard Django development settings including REST framework configuration
- register `modules.samples` and `modules.protocols` apps and middleware
- document overriding settings via environment variables

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6894df807d2883319234baa0acee1bd4