### PR TITLE
Rename Sample type field to sample_type

### DIFF
--- a/bionexus-platform/backend/modules/samples/migrations/0002_rename_type_to_sample_type.py
+++ b/bionexus-platform/backend/modules/samples/migrations/0002_rename_type_to_sample_type.py
@@ -1,0 +1,15 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("samples", "0001_initial"),
+    ]
+
+    operations = [
+        migrations.RenameField(
+            model_name="sample",
+            old_name="type",
+            new_name="sample_type",
+        ),
+    ]

--- a/bionexus-platform/backend/modules/samples/models.py
+++ b/bionexus-platform/backend/modules/samples/models.py
@@ -5,7 +5,7 @@ class Sample(models.Model):
     """Model representing a biological sample."""
 
     name = models.CharField(max_length=255)
-    type = models.CharField(max_length=100)
+    sample_type = models.CharField(max_length=100)
     received_at = models.DateTimeField()
     location = models.CharField(max_length=255)
 

--- a/bionexus-platform/backend/modules/samples/serializers.py
+++ b/bionexus-platform/backend/modules/samples/serializers.py
@@ -8,4 +8,4 @@ class SampleSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Sample
-        fields = "__all__"
+        fields = ["id", "name", "sample_type", "received_at", "location"]

--- a/bionexus-platform/backend/modules/samples/tests/test_samples_api.py
+++ b/bionexus-platform/backend/modules/samples/tests/test_samples_api.py
@@ -12,7 +12,7 @@ class SampleAPITest(TestCase):
     def test_sample_crud_operations(self):
         payload = {
             "name": "Sample A",
-            "type": "blood",
+            "sample_type": "blood",
             "received_at": timezone.now().isoformat(),
             "location": "Freezer 1",
         }


### PR DESCRIPTION
## Summary
- rename `Sample.type` to `sample_type`
- update serializer, tests, and add migration

## Testing
- `python bionexus-platform/backend/manage.py migrate` *(fails: IndentationError: unexpected indent in core/settings.py)*
- `pytest` *(fails: IndentationError: unexpected indent in core/settings.py)*

------
https://chatgpt.com/codex/tasks/task_e_68950e8cf5608331899430d352c5fb11