### PR TITLE
Pin backend dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           python-version: '3.9'
 
-      - name: Install dependencies
+      - name: Install pinned dependencies
         run: |
           pip install --upgrade pip
           pip install -r bionexus-platform/backend/requirements.txt

--- a/bionexus-platform/backend/README.md
+++ b/bionexus-platform/backend/README.md
@@ -1,5 +1,19 @@
 # Backend
 
+## Dependencies
+
+The backend relies on pinned Python packages to ensure consistent environments:
+
+- Django 5.2.5
+- Django REST Framework 3.16.1
+- Pytest 8.4.1
+
+Install them with:
+
+```bash
+pip install -r requirements.txt
+```
+
 ## Applying Database Migrations
 
 To apply the latest migrations for the `samples` and `protocols` apps:

--- a/bionexus-platform/backend/requirements.txt
+++ b/bionexus-platform/backend/requirements.txt
@@ -1,3 +1,3 @@
-django
-djangorestframework
-pytest
+django==5.2.5
+djangorestframework==3.16.1
+pytest==8.4.1


### PR DESCRIPTION
## Summary
- pin Django, DRF and pytest versions in backend requirements
- document pinned backend dependencies and installation
- clarify CI workflow step for installing pinned dependencies

## Testing
- `pip install -r bionexus-platform/backend/requirements.txt`
- `cd bionexus-platform/backend && pytest -q` *(fails: django.core.exceptions.ImproperlyConfigured: Requested setting REST_FRAMEWORK, but settings are not configured)*

------
https://chatgpt.com/codex/tasks/task_e_68950e8ce9e4833182164a31c0f7064b