### PR TITLE
refactor: streamline Django settings

### DIFF
--- a/bionexus-platform/backend/core/settings.py
+++ b/bionexus-platform/backend/core/settings.py
@@ -1,50 +1,27 @@
- codex/add-standard-settings-and-documentation
 import os
 from pathlib import Path
 
- codex/add-modules.protocols-to-installed_apps
 """Django settings for the BioNexus project."""
-
-from __future__ import annotations
-
-from pathlib import Path
-import os
- main
 
 # Base directory of the project
 BASE_DIR = Path(__file__).resolve().parent.parent
 
+
 # --- Core Django settings -------------------------------------------------
 
 # SECURITY WARNING: keep the secret key used in production secret!
-
- codex/add-standard-settings-and-documentation
-# SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = os.environ.get("DJANGO_DEBUG", "true").lower() == "true"
-
-ALLOWED_HOSTS = os.environ.get(
-    "DJANGO_ALLOWED_HOSTS", "localhost,127.0.0.1,testserver"
-).split(",")
-
-
-from pathlib import Path
-import os
-
-BASE_DIR = Path(__file__).resolve().parent.parent
-
- codex/remove-trivial-backend/test_example.py
- main
 SECRET_KEY = os.environ.get("DJANGO_SECRET_KEY", "dev-secret-key")
-DEBUG = True
-ALLOWED_HOSTS: list[str] = ["testserver", "localhost"]
 
- codex/add-modules.protocols-to-installed_apps
-ALLOWED_HOSTS: list[str] = []
+# SECURITY WARNING: don't run with debug turned on in production!
+DEBUG = os.environ.get("DJANGO_DEBUG", "false").lower() == "true"
 
- main
+_allowed_hosts = os.environ.get(
+    "DJANGO_ALLOWED_HOSTS", "localhost,127.0.0.1,testserver"
+)
+ALLOWED_HOSTS = [host for host in _allowed_hosts.split(",") if host]
+
+
 # Application definition
-
- main
 INSTALLED_APPS = [
     "django.contrib.admin",
     "django.contrib.auth",
@@ -55,8 +32,6 @@ INSTALLED_APPS = [
     "rest_framework",
     "modules.samples",
     "modules.protocols",
- codex/add-standard-settings-and-documentation
-
 ]
 
 MIDDLEWARE = [
@@ -89,105 +64,15 @@ TEMPLATES = [
 
 WSGI_APPLICATION = "core.wsgi.application"
 
- codex/add-modules.protocols-to-installed_apps
-# Database configuration
 
- main
+# Database configuration
 DATABASES = {
     "default": {
         "ENGINE": "django.db.backends.sqlite3",
         "NAME": BASE_DIR / "db.sqlite3",
- codex/add-modules.protocols-to-installed_apps
     }
 }
 
-# Django REST Framework configuration
-REST_FRAMEWORK = {
-    "DEFAULT_AUTHENTICATION_CLASSES": [
-        "rest_framework.authentication.SessionAuthentication",
-        "rest_framework.authentication.BasicAuthentication",
-    ],
-    "DEFAULT_PERMISSION_CLASSES": [
-        "rest_framework.permissions.AllowAny",
-    ],
-}
-
-# Internationalization
-LANGUAGE_CODE = "en-us"
-
-TIME_ZONE = "UTC"
-
-USE_I18N = True
-
-USE_TZ = True
-
-# Static files
-STATIC_URL = "static/"
-
-DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
-
-
-
-SECRET_KEY = os.environ.get('DJANGO_SECRET_KEY', 'dev-secret-key')
-DEBUG = True
-ALLOWED_HOSTS: list[str] = ['testserver','localhost','127.0.0.1']
-
-INSTALLED_APPS = [
-    'django.contrib.admin',
-    'django.contrib.auth',
-    'django.contrib.contenttypes',
-    'django.contrib.sessions',
-    'django.contrib.messages',
-    'django.contrib.staticfiles',
-    'rest_framework',
-    'modules.samples',
-    'modules.protocols',
- main
-]
-
-MIDDLEWARE = [
-    'django.middleware.security.SecurityMiddleware',
-    'django.contrib.sessions.middleware.SessionMiddleware',
-    'django.middleware.common.CommonMiddleware',
-    'django.middleware.csrf.CsrfViewMiddleware',
-    'django.contrib.auth.middleware.AuthenticationMiddleware',
-    'django.contrib.messages.middleware.MessageMiddleware',
-    'django.middleware.clickjacking.XFrameOptionsMiddleware',
-]
-
-ROOT_URLCONF = 'core.urls'
-
-TEMPLATES = [
-    {
-        'BACKEND': 'django.template.backends.django.DjangoTemplates',
-        'DIRS': [],
-        'APP_DIRS': True,
-        'OPTIONS': {
-            'context_processors': [
-                'django.template.context_processors.debug',
-                'django.template.context_processors.request',
-                'django.contrib.auth.context_processors.auth',
-                'django.contrib.messages.context_processors.messages',
-            ],
-        },
-    },
-]
-
-WSGI_APPLICATION = 'core.wsgi.application'
-
- codex/add-standard-settings-and-documentation
-# Database configuration
-
- main
-DATABASES = {
-    'default': {
-        'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': BASE_DIR / 'db.sqlite3',
- main
-    }
-}
-
- codex/add-standard-settings-and-documentation
 DATABASE_URL = os.environ.get("DATABASE_URL")
 if DATABASE_URL:
     try:
@@ -197,11 +82,9 @@ if DATABASE_URL:
     else:
         DATABASES["default"] = dj_database_url.parse(DATABASE_URL)
 
-# Django REST Framework configuration
 
- main
+# Django REST Framework configuration
 REST_FRAMEWORK = {
- codex/remove-trivial-backend/test_example.py
     "DEFAULT_AUTHENTICATION_CLASSES": [
         "rest_framework.authentication.SessionAuthentication",
         "rest_framework.authentication.BasicAuthentication",
@@ -211,42 +94,19 @@ REST_FRAMEWORK = {
     ],
 }
 
- codex/add-standard-settings-and-documentation
-# Internationalization
 
- main
+# Internationalization
 LANGUAGE_CODE = "en-us"
+
 TIME_ZONE = "UTC"
+
 USE_I18N = True
+
 USE_TZ = True
 
- codex/add-standard-settings-and-documentation
+
 # Static files
 STATIC_URL = "static/"
 
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 
-
-STATIC_URL = "static/"
-DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
-
-    'DEFAULT_AUTHENTICATION_CLASSES': [
-        'rest_framework.authentication.SessionAuthentication',
-        'rest_framework.authentication.BasicAuthentication',
-    ],
-    'DEFAULT_PERMISSION_CLASSES': [
-        'rest_framework.permissions.AllowAny',
-    ],
-}
-
-LANGUAGE_CODE = 'en-us'
-TIME_ZONE = 'UTC'
-USE_I18N = True
-USE_TZ = True
-
-STATIC_URL = 'static/'
-
-DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
- main
- main
- main


### PR DESCRIPTION
## Summary
- clean up Django settings and remove codex markers
- configure DEBUG and ALLOWED_HOSTS from environment variables
- consolidate database and REST framework setup

## Testing
- `pytest bionexus-platform/backend/modules/samples/tests/test_samples_api.py::SampleAPITest::test_sample_crud_operations -q` *(fails: IndentationError in core/urls.py)*

------
https://chatgpt.com/codex/tasks/task_e_68950e88e71c8331958087808273c89b