### PR TITLE
Clean up core URL configuration

### DIFF
--- a/bionexus-platform/backend/core/urls.py
+++ b/bionexus-platform/backend/core/urls.py
@@ -5,27 +5,9 @@ from modules.samples.views import SampleViewSet
 from modules.protocols.views import ProtocolViewSet
 
 router = DefaultRouter()
- codex/remove-trivial-backend/test_example.py
 router.register(r"samples", SampleViewSet)
 router.register(r"protocols", ProtocolViewSet, basename="protocol")
 
- codex/refactor-urls.py-for-routing
 urlpatterns = [
     path("api/", include(router.urls)),
-
- codex/add-standard-settings-and-documentation
-urlpatterns = [
-    path("api/", include(router.urls)),
-
-urlpatterns = [
-    path("api/", include(router.urls)),
-
-router.register(r'samples', SampleViewSet)
-router.register(r'protocols', ProtocolViewSet, basename='protocol')
-
-urlpatterns = [
-    path('api/', include(router.urls)),
- main
- main
- main
 ]


### PR DESCRIPTION
## Summary
- remove merge artifacts from core URL config
- register routers once and expose a single `urlpatterns`

## Testing
- `pytest` *(fails: IndentationError in core/settings.py)*
- `python -m py_compile bionexus-platform/backend/core/urls.py`


------
https://chatgpt.com/codex/tasks/task_e_68950e8991f88331b7379569ccfb487f